### PR TITLE
Graphgen improvements

### DIFF
--- a/graphgen.lua
+++ b/graphgen.lua
@@ -102,6 +102,7 @@ local function generateGraph(net, input, opts)
 
   local storageHash = {}
   local nodes = {}
+  local trickyNodes = {}
 
   local g = graph.Graph()
 
@@ -168,7 +169,17 @@ local function generateGraph(net, input, opts)
 
       nodes[toPtr] = nodes[toPtr] or createNode(name,to)
 
-      assert(nodes[fromPtr], 'Parent node inexistant for module '.. name)
+      --assert(nodes[fromPtr], 'Parent node inexistant for module '.. name)
+      if not nodes[fromPtr] then
+        --[[
+        print('Printing debug')
+        print(debug.getinfo(2))
+        --]]
+
+        nodes[fromPtr] = createNode('oups',from)
+        table.insert(trickyNodes, fromPtr)
+        trickyNodes[fromPtr] = nodes[fromPtr]
+      end
       
       -- insert edge
       g:add(graph.Edge(nodes[fromPtr],nodes[toPtr]))
@@ -199,7 +210,14 @@ local function generateGraph(net, input, opts)
         -- those containers effectively do some computation, so they have their
         -- place in the graph
         for i,branch in ipairs(m.modules) do
-          local last_module = branch:get(branch:size())
+          --local last_module = branch:get(branch:size())
+          local last_module
+          if branch.modues then
+            last_module = branch:get(#branch.modules)
+          else
+            last_module = branch
+          end
+
           local out = last_module.output
           local ptr = torch.pointer(out)
 

--- a/graphgen.lua
+++ b/graphgen.lua
@@ -281,9 +281,6 @@ local function generateGraph(net, input, opts)
 
   createBoundaryNode(input, 'Input')
 
-  -- fill the states from each tensor
-  --net:forward(input)
-
   hackTorch()
   -- overwriting the standard functions to generate our graph
   net:apply(apply_func)


### PR DESCRIPTION
Should fix https://github.com/fmassa/optimize-net/issues/6
There is a lot of magic going on in here:
* temporarily overwrite torch `__index` and `select` to keep track of the modules in which those functions were called (thanks upvalues !)
* if the `input` tensors are not found in `nodes` table, look for them in the `trickyNodes` table, which contains the tensors created via `__index` and `select` during the forward call
* additionally, remove the need of having to run forward before generating the graph to pre-allocate `self.output`, by adding the `output` edges after each module's call.

cc @szagoruyko